### PR TITLE
#105 Now using DatabaseClientFactory.Bean to assist with DatabaseClie…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,13 @@ repositories {
 }
 
 dependencies {
-  compile 'com.marklogic:marklogic-client-api:4.1.1'
-  compile 'com.marklogic:marklogic-xcc:9.0.3'
+  compile 'com.marklogic:marklogic-client-api:4.2.0'
+  compile 'com.marklogic:marklogic-xcc:9.0.9'
   compile 'org.jdom:jdom2:2.0.6'
-  compile 'org.springframework:spring-context:4.3.7.RELEASE'
+  compile 'org.springframework:spring-context:5.1.6.RELEASE'
 
   testCompile 'junit:junit:4+'
-  testCompile 'org.springframework:spring-test:4.3.7.RELEASE'
+  testCompile 'org.springframework:spring-test:5.1.6.RELEASE'
 
   // Used for testing loading modules from the classpath
   testRuntime files("lib/modules.jar")


### PR DESCRIPTION
…nt construction

The Bean class won't build the SecurityContext though, so DefaultConfiguredDatabaseClientFactory must still do that.

There's no new functionality from this, so I ran all of the tests on ml-javaclient-util. Going to do likewise in ml-app-deployer. But the thinking is there's less code now in ml-javaclient-util, as the Bean class is handling more of the work. 