### PR TITLE
Upgrade MarkLogic XCC to 10.0.9, and marklogic-client-api to 5.5.2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,11 +17,13 @@ repositories {
 }
 
 dependencies {
-  api 'com.marklogic:marklogic-client-api:5.5.0'
-  api 'com.marklogic:marklogic-xcc:10.0.7'
+	api 'com.fasterxml.jackson.core:jackson-databind:2.12.4'
+  api 'com.marklogic:marklogic-client-api:5.5.2'
+  api 'com.marklogic:marklogic-xcc:10.0.9'
+	api 'org.slf4j:slf4j-api:1.7.30'
   api 'org.springframework:spring-context:5.3.9'
 
-  implementation 'org.jdom:jdom2:2.0.6'
+	implementation 'org.jdom:jdom2:2.0.6'
 
 	// This isn't the latest release, but it matches what is used by the ML Java Client
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.1'

--- a/build.gradle
+++ b/build.gradle
@@ -17,16 +17,14 @@ repositories {
 }
 
 dependencies {
-	api 'com.fasterxml.jackson.core:jackson-databind:2.12.4'
   api 'com.marklogic:marklogic-client-api:5.5.2'
   api 'com.marklogic:marklogic-xcc:10.0.9'
-	api 'org.slf4j:slf4j-api:1.7.30'
   api 'org.springframework:spring-context:5.3.9'
 
-	implementation 'org.jdom:jdom2:2.0.6'
+  implementation 'org.jdom:jdom2:2.0.6'
 
 	// This isn't the latest release, but it matches what is used by the ML Java Client
-	implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.1'
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.4'
 
 	// This is currently an implementation dependency, though perhaps should be an api dependency due to its usage in
 	// LoggingObject; not clear yet on whether the protected Logger in that class should make this an api dependency or not

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,8 @@
 plugins {
-  id "java-library"
-  id "maven-publish"
-  id "eclipse"
-  id "idea"
-	id "com.jfrog.bintray" version "1.8.4"
+	id "java-library"
+	id "maven-publish"
+	id "signing"
 	id "com.github.jk1.dependency-license-report" version "1.3"
-
-	id "net.saliman.properties" version "1.5.1"
 	id "io.snyk.gradle.plugin.snykplugin" version "0.4"
 }
 


### PR DESCRIPTION
 Due to changes in how marklogic-client-api dependencies are declared, `implementation` "hides" jackson-databind and slf4j and need to be explicitly added.

Removed jcenter() and the MarkLogic maven repo