### PR TITLE
Adjust export/import to preserve query elements

### DIFF
--- a/src/main/java/com/marklogic/client/ext/qconsole/impl/QconsoleScripts.java
+++ b/src/main/java/com/marklogic/client/ext/qconsole/impl/QconsoleScripts.java
@@ -1,169 +1,26 @@
 package com.marklogic.client.ext.qconsole.impl;
 
-/**
- * This scripts are defined as strings so that it's easy to reuse this in an environment like Gradle without
- * having to read files from the classpath.
- */
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
 public class QconsoleScripts {
 
-	/**
-	 * This relies on internal APIs in the qconsole-model function that have changed between MarkLogic 8 and 9.
-	 * Specifically, qconsole-model:default-content-source() in ML8 was removed and qconsole-model:default-database()
-	 * can be used instead.
-	 */
-	public static final String IMPORT = "xquery version \"1.0-ml\";\n" +
-		"\n" +
-		"declare namespace qconsole=\"http://marklogic.com/appservices/qconsole\";\n" +
-		"\n" +
-		"import module namespace amped-qconsole = \"http://marklogic.com/appservices/qconsole/util-amped\" at \"/MarkLogic/appservices/qconsole/qconsole-amped.xqy\";\n" +
-		"import module namespace idecl = \"http://marklogic.com/appservices/qconsole/decl\" at \"/MarkLogic/appservices/qconsole/qconsole-decl.xqy\";\n" +
-		"import module namespace qconsole-model = \"http://marklogic.com/appservices/qconsole/model\" at \"/MarkLogic/appservices/qconsole/qconsole-model.xqy\";\n" +
-		"\n" +
-		"declare namespace eval = \"xdmp:eval\";\n" +
-		"\n" +
-		"declare variable $exported-workspace as node() external;\n" +
-		"declare variable $user as xs:string external;\n" +
-		"\n" +
-		"declare function local:qconsole-eval(\n" +
-		"    $xquery as xs:string,\n" +
-		"    $vars as item()*,\n" +
-		"    $options as element(eval:options)?\n" +
-		") as item()*\n" +
-		"{   xdmp:log(text{(\"local:qconsole-eval\", xdmp:quote($vars))}),\n" +
-		"    xdmp:security-assert(\"http://marklogic.com/xdmp/privileges/qconsole\", \"execute\"),\n" +
-		"    xdmp:eval($xquery, $vars, <options xmlns=\"xdmp:eval\">\n" +
-		"            <database>{xdmp:database(\"App-Services\")}</database>\n" +
-		"          </options>)\n" +
-		"};\n" +
-		"\n" +
-		"declare function local:import-workspace(\n" +
-		"    $workspace as element(),\n" +
-		"    $user as xs:string \n" +
-		") as xs:string*\n" +
-		"{\n" +
-		"    let $eval-query :=\n" +
-		"       'declare namespace qconsole = \"http://marklogic.com/appservices/qconsole\";\n" +
-		"        import module namespace qconsole-model=\"http://marklogic.com/appservices/qconsole/model\"\n" +
-		"            at \"/MarkLogic/appservices/qconsole/qconsole-model.xqy\";\n" +
-		"        import module namespace amped-qconsole = \"http://marklogic.com/appservices/qconsole/util-amped\"\n" +
-		"            at \"/MarkLogic/appservices/qconsole/qconsole-amped.xqy\";\n" +
-		"        declare variable $xquery-query-template as xs:string external;\n" +
-		"        declare variable $workspace as element(export) external;\n" +
-		"        declare variable $user as xs:string external;\n" +
-		"        let $_ := xdmp:log(text{(\"user\", $user)})\n" +
-		"        let $wsid := xdmp:random()\n" +
-		"        let $imported-wsname := string($workspace/workspace/@name)\n" +
-		"        let $existing-wsnames := amped-qconsole:qconsole-get-user-workspaces(())/qconsole:name/string()\n" +
-		"        let $wsname :=\n" +
-		"            if( $imported-wsname = $existing-wsnames )\n" +
-		"            then qconsole-model:generate-workspace-name(())\n" +
-		"            else $imported-wsname\n" +
-		"        let $queries := $workspace/workspace/query\n" +
-		"        let $userid := xdmp:user($user)\n" +
-		"        let $_ := xdmp:log(text{(\"userid\", $userid)})\n" +
-		"        let $ws :=  <qconsole:workspace>\n" +
-		"                        <qconsole:id>{$wsid}</qconsole:id>\n" +
-		"                        <qconsole:name>{$wsname}</qconsole:name>\n" +
-		"                        <qconsole:security>\n" +
-		"                            <qconsole:userid>{$userid}</qconsole:userid>\n" +
-		"                        </qconsole:security>\n" +
-		"                        <qconsole:active>true</qconsole:active>\n" +
-		"                        <qconsole:queries>\n" +
-		"                            {\n" +
-		"                            for $q at $i in $queries\n" +
-		"                            let $qid := xdmp:random()\n" +
-		"                            let $qname := string($q/@name)\n" +
-		"                            let $focus := string($q/@focus)\n" +
-		"                            let $active := string($q/@active)\n" +
-		"                            let $content-source :=\n" +
-		"                                if ( exists($q/@content-source) )\n" +
-		"                                then string($q/@content-source)\n" +
-		"                                else qconsole-model:default-database()\n" +
-		"                            let $mode := string($q/@mode)\n" +
-		"                            let $query-text := text { $q }\n" +
-		"                            let $q-uri := concat(\"/queries/\", $qid, \".txt\")\n" +
-		"                            let $save-q := amped-qconsole:qconsole-document-insert($q-uri, $query-text)\n" +
-		"                            return\n" +
-		"                            <qconsole:query>\n" +
-		"                                <qconsole:id>{$qid}</qconsole:id>\n" +
-		"                                <qconsole:name>{$qname}</qconsole:name>\n" +
-		"                                <qconsole:content-source>{$content-source}</qconsole:content-source>\n" +
-		"                                <qconsole:active>{$active}</qconsole:active>\n" +
-		"                                <qconsole:focus>{$focus}</qconsole:focus>\n" +
-		"                                <qconsole:mode>{$mode}</qconsole:mode>\n" +
-		"                            </qconsole:query>\n" +
-		"                            }\n" +
-		"                        </qconsole:queries>\n" +
-		"                    </qconsole:workspace>\n" +
-		"        let $ws-uri := concat(\"/workspaces/\", $wsid, \".xml\")\n" +
-		"        let $save-ws := amped-qconsole:qconsole-document-insert($ws-uri, $ws)\n" +
-		"        let $set-active := qconsole-model:set-only-one-workspace-active($wsid)\n" +
-		"        return $wsid'\n" +
-		"            \n" +
-		"    let $new-wsid := \n" +
-		"        local:qconsole-eval($eval-query, \n" +
-		"            (xs:QName(\"workspace\"), $workspace, \n" +
-		"            xs:QName(\"xquery-query-template\"), $idecl:default-query-text,\n" +
-		"            xs:QName(\"user\"), $user), ())\n" +
-		"    let $ws-uri := concat(\"/workspaces/\", $new-wsid, \".xml\")\n" +
-		"    return $ws-uri\n" +
-		"};\n" +
-		"\n" +
-		"local:import-workspace($exported-workspace/element(), $user)";
+	private final static String MODULE_PATH = "com/marklogic/client/ext/qconsole/impl/";
+	public static final String IMPORT;
+	public final static String EXPORT;
+	static {
+		IMPORT = readFile( MODULE_PATH + "import-workspaces.xqy");
+		EXPORT = readFile(MODULE_PATH + "export-workspaces.xqy");
+	}
 
-	public final static String EXPORT = "xquery version \"1.0-ml\";\n" +
-		"\n" +
-		"declare namespace qconsole=\"http://marklogic.com/appservices/qconsole\";\n" +
-		"\n" +
-		"declare variable $user as xs:string external;\n" +
-		"declare variable $workspace as xs:string external;\n" +
-		"\n" +
-		"declare function local:do-eval($query as xs:string, $vars) {\n" +
-		"  xdmp:eval($query, $vars, \n" +
-		"      <options xmlns=\"xdmp:eval\">\n" +
-		"      <database>{xdmp:database(\"App-Services\")}</database>\n" +
-		"      </options>)\n" +
-		"};\n" +
-		"\n" +
-		"declare function local:get-ws-uri($user as xs:string, $workspace as xs:string) {\n" +
-		"  let $ws-query := 'xquery version \"1.0-ml\";\n" +
-		"    declare namespace qconsole = \"http://marklogic.com/appservices/qconsole\";\n" +
-		"    declare variable $user as xs:string external;\n" +
-		"    declare variable $workspace as xs:string external;\n" +
-		"    cts:uris((), (), cts:and-query((\n" +
-		"        cts:directory-query(\"/workspaces/\"),\n" +
-		"        cts:element-value-query(xs:QName(\"qconsole:userid\"), xs:string(xdmp:user($user))),\n" +
-		"        cts:element-value-query(xs:QName(\"qconsole:name\"), $workspace)\n" +
-		"    ))\n" +
-		"    )'\n" +
-		"  return local:do-eval($ws-query, (xs:QName(\"user\"), $user, xs:QName(\"workspace\"), $workspace))\n" +
-		"};\n" +
-		"\n" +
-		"declare function local:get-workspace($ws-uri as xs:string) {\n" +
-		"  let $query := \"declare variable $ws-uri as xs:string external; fn:doc($ws-uri)\"\n" +
-		"  return local:do-eval($query, (xs:QName(\"ws-uri\"), $ws-uri))\n" +
-		"};\n" +
-		"\n" +
-		"let $user := ($user, xdmp:get-current-user())[1]\n" +
-		"\n" +
-		"let $ws-uri := local:get-ws-uri($user, $workspace)\n" +
-		"let $ws := local:get-workspace($ws-uri)\n" +
-		"let $queries := \n" +
-		"    for $q in $ws/qconsole:workspace/qconsole:queries/qconsole:query\n" +
-		"    return \n" +
-		"      <query name=\"{string($q/qconsole:name)}\" focus=\"{string($q/qconsole:focus)}\" active=\"{string($q/qconsole:active)}\" mode=\"{string($q/qconsole:mode)}\">\n" +
-		"        {local:do-eval(concat(\"fn:doc('/queries/\", xs:unsignedLong($q/qconsole:id), \".txt')\"), ())}\n" +
-		"      </query>\n" +
-		"\n" +
-		"let $export := \n" +
-		"    if ($queries) then (\n" +
-		"    <export>\n" +
-		"      <workspace name=\"{string($ws/qconsole:workspace/qconsole:name)}\">\n" +
-		"        {$queries}\n" +
-		"      </workspace>\n" +
-		"    </export> )\n" +
-		"    else (text{\"No workspace found with the name of \", $workspace, \".\"})\n" +
-		"\n" +
-		"return $export";
-
+	private static String readFile(String fileName){
+		InputStream inputStream = QconsoleScripts.class.getClassLoader().getResourceAsStream(fileName);
+		return new BufferedReader(
+			new InputStreamReader(inputStream, StandardCharsets.UTF_8))
+			.lines()
+			.collect(Collectors.joining("\n"));
+	}
 }

--- a/src/main/resources/com/marklogic/client/ext/qconsole/impl/export-workspaces.xqy
+++ b/src/main/resources/com/marklogic/client/ext/qconsole/impl/export-workspaces.xqy
@@ -1,0 +1,54 @@
+xquery version "1.0-ml";
+
+declare namespace qconsole="http://marklogic.com/appservices/qconsole";
+
+declare variable $user as xs:string external;
+declare variable $workspace as xs:string external;
+
+declare function local:do-invoke($function as xdmp:function) {
+	xdmp:invoke-function($function,
+		<options xmlns="xdmp:eval">
+			<database>{xdmp:database("App-Services")}</database>
+		</options>)
+};
+
+declare function local:get-workspace-uri($user as xs:string, $workspace as xs:string) {
+	let $workspace-query := function() {
+		cts:uris((), (), cts:and-query((
+			cts:directory-query("/workspaces/"),
+			cts:element-value-query(xs:QName("qconsole:userid"), xs:string(xdmp:user($user))),
+			cts:element-value-query(xs:QName("qconsole:name"), $workspace)
+		)))
+	}
+	return local:do-invoke($workspace-query)
+};
+
+declare function local:get-workspace($ws-uri as xs:string) {
+	let $query := function() { fn:doc($ws-uri) }
+	return local:do-invoke($query)
+};
+
+declare function local:to-attribute($element as element()) {
+	attribute { $element/local-name() } { string($element) }
+};
+
+let $user := ($user, xdmp:get-current-user())[1]
+let $workspace-uri := local:get-workspace-uri($user, $workspace)
+let $workspace := local:get-workspace($workspace-uri)
+let $queries :=
+	for $query in $workspace/qconsole:workspace/qconsole:queries/qconsole:query
+	return
+		<query>{
+        $query/qconsole:* ! local:to-attribute(.),
+			  local:do-invoke(function() {fn:doc("/queries/" || xs:string($query/qconsole:id) || ".txt")})
+		}</query>
+return
+	if ($queries)
+	then
+		<export>
+			<workspace name="{string($workspace/qconsole:workspace/qconsole:name)}">
+				{$queries}
+			</workspace>
+		</export>
+	else
+		text{ "No workspace found with the name of ", $workspace, "." }

--- a/src/main/resources/com/marklogic/client/ext/qconsole/impl/import-workspaces.xqy
+++ b/src/main/resources/com/marklogic/client/ext/qconsole/impl/import-workspaces.xqy
@@ -1,0 +1,109 @@
+xquery version "1.0-ml";
+(:
+  This relies on internal APIs in the qconsole-model function that have changed between MarkLogic 8 and 9.
+  Specifically, qconsole-model:default-content-source() in ML8 was removed and qconsole-model:default-database()
+  can be used instead.
+:)
+declare namespace qconsole = "http://marklogic.com/appservices/qconsole";
+
+import module namespace amped-qconsole = "http://marklogic.com/appservices/qconsole/util-amped" at "/MarkLogic/appservices/qconsole/qconsole-amped.xqy";
+import module namespace qconsole-model = "http://marklogic.com/appservices/qconsole/model" at "/MarkLogic/appservices/qconsole/qconsole-model.xqy";
+
+declare variable $exported-workspace as node() external;
+declare variable $user as xs:string external;
+
+declare function local:qconsole-invoke(
+	$xquery as xdmp:function
+) as item()*
+{
+	xdmp:security-assert("http://marklogic.com/xdmp/privileges/qconsole", "execute"),
+	xdmp:invoke-function($xquery,
+		<options xmlns="xdmp:eval">
+			<database>{xdmp:database("App-Services")}</database>
+		</options>)
+};
+
+declare function local:workspace-uri($workspace-id) {
+	"/workspaces/" || xs:string($workspace-id) || ".xml"
+};
+
+declare function local:import-workspace(
+	$workspace as element(),
+	$user as xs:string
+) as xs:string*
+{
+  let $query := function() {
+    let $_ := xdmp:log(text{("user", $user)})
+    let $workspace-id := xdmp:random()
+    let $imported-workspace-name := string($workspace/workspace/@name)
+    let $existing-workspace-names := amped-qconsole:qconsole-get-user-workspaces(())/qconsole:name/string()
+    let $workspace-name :=
+      if ($imported-workspace-name = $existing-workspace-names)
+      then qconsole-model:generate-workspace-name(())
+      else $imported-workspace-name
+    let $queries := $workspace/workspace/query
+    let $user-id := xdmp:user($user)
+    let $_ := xdmp:log(text{("userid", $user-id)})
+    let $workspace :=
+		  <qconsole:workspace>
+			  <qconsole:id>{$workspace-id}</qconsole:id>
+				<qconsole:name>{$workspace-name}</qconsole:name>
+				<qconsole:security>
+				  <qconsole:userid>{$user-id}</qconsole:userid>
+				</qconsole:security>
+				<qconsole:active>true</qconsole:active>
+				<qconsole:queries>{
+					for $query in $queries
+					let $source :=
+						if (exists($query/@content-source))
+						then qconsole-model:convert-content-source($query/@content-source)
+						else
+							let $s := map:map()
+							let $database-name :=
+								if (exists($query/@database-name) and string-length($query/@database-name) gt 0)
+								then $query/@database-name ! (., map:put($s, ./local-name(), .))
+								else ""
+							let $database :=
+								let $db-id :=
+									if ( (exists($query/@database) and string-length($query/@database) gt 0) or string-length($database-name) gt 0 )
+									then qconsole-model:identify-resource("database", $query/@database, $database-name)
+									else qconsole-model:default-database()
+								let $_ := map:put($s, "database", $db-id)
+								return $db-id
+							let $server-name :=
+								if (exists($query/@server-name) and string-length($query/@server-name) gt 0)
+								then $query/@server-name ! (., map:put($s, ./local-name(), .))
+								else ""
+							let $server :=
+								let $server-id :=
+									if ( (exists($query/@server) and string-length($query/@server) gt 0) or string-length($server-name) gt 0 )
+									then qconsole-model:identify-resource("server", $query/@server, $server-name)
+									else qconsole-model:default-app-server($database)
+								let $_ := map:put($s, "server", $server-id)
+								return $server-id
+							return $s
+					let $_ :=
+					  for $item in ($query/@*[not(local-name() = ("id", "database", "database-name", "server", "server-name"))])
+			      return map:put($source, $item/local-name(), $item)
+					let $query-text := text {$query}
+					let $query-id := xdmp:random()
+					let $query-uri := concat("/queries/", $query-id, ".txt")
+					let $save-query := amped-qconsole:qconsole-document-insert($query-uri, $query-text)
+					return
+						<qconsole:query>
+							<qconsole:id>{$query-id}</qconsole:id>
+							{ map:keys($source) ! element {"qconsole:" || .} { string(map:get($source, .)) } }
+						</qconsole:query>
+				}</qconsole:queries>
+			</qconsole:workspace>
+    let $workspace-uri := local:workspace-uri($workspace-id)
+    let $save-workspace := amped-qconsole:qconsole-document-insert($workspace-uri, $workspace)
+    let $set-active := qconsole-model:set-only-one-workspace-active($workspace-id)
+    return $workspace-id
+	}
+	let $new-wsid := local:qconsole-invoke($query)
+	let $workspace-uri := local:workspace-uri($new-wsid)
+	return $workspace-uri
+};
+
+local:import-workspace($exported-workspace/element(), $user)

--- a/src/test/java/com/marklogic/client/ext/qconsole/impl/QconsoleScriptsTest.java
+++ b/src/test/java/com/marklogic/client/ext/qconsole/impl/QconsoleScriptsTest.java
@@ -1,0 +1,23 @@
+package com.marklogic.client.ext.qconsole.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class QconsoleScriptsTest {
+
+	@Test
+	public void testImport() {
+		String importModule = QconsoleScripts.IMPORT;
+		assertNotNull(importModule);
+		assertTrue(importModule.startsWith("xquery version"));
+	}
+
+	@Test
+	public void testExport() {
+		String exportModule = QconsoleScripts.EXPORT;
+		assertNotNull(exportModule);
+		assertTrue(exportModule.startsWith("xquery version"));
+	}
+}


### PR DESCRIPTION
This addresses the issue raised in ml-gradle: https://github.com/marklogic-community/ml-gradle/issues/612

Ensures that the following are preserved on export/import
- listorder
- taborder
- database
- server
- optimize

Even though exported, MarkLogic import doesn't import the following (but will put back in place as you switch tabs)
- database-name
- server-name
Assumption is that it was intentional, if `id` matches and can lookup the name, then no need to set it on import?

Also externalized the XQuery into files, rather than escaped strings embedded in Java classes (yuck) to make it easier to read and debug