### PR TITLE
TDE validation now works on ML versions < 10.0-9

### DIFF
--- a/src/main/java/com/marklogic/client/ext/file/AbstractDocumentFileReader.java
+++ b/src/main/java/com/marklogic/client/ext/file/AbstractDocumentFileReader.java
@@ -55,7 +55,7 @@ public abstract class AbstractDocumentFileReader extends LoggingObject {
 				}
 				documentFile = processor.processDocumentFile(documentFile);
 			} catch (Exception e) {
-				final String message = "Error while processing document file: " + documentFile.getFile();
+				final String message = "Error while processing file: " + documentFile.getFile() + "; cause: " + e.getMessage();
 				if (catchProcessingError) {
 					logger.error(message, e);
 				} else {

--- a/src/main/java/com/marklogic/client/ext/file/DocumentFile.java
+++ b/src/main/java/com/marklogic/client/ext/file/DocumentFile.java
@@ -7,7 +7,6 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
-import com.marklogic.client.io.marker.DocumentMetadataWriteHandle;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 
@@ -65,7 +64,7 @@ public class DocumentFile {
 		return DocumentWriteOperation.OperationType.DOCUMENT_WRITE;
 	}
 
-	public DocumentMetadataWriteHandle getMetadata() {
+	public DocumentMetadataHandle getMetadata() {
 		return documentMetadata;
 	}
 

--- a/src/main/java/com/marklogic/client/ext/file/GenericFileLoader.java
+++ b/src/main/java/com/marklogic/client/ext/file/GenericFileLoader.java
@@ -73,18 +73,22 @@ public class GenericFileLoader extends LoggingObject implements FileLoader {
 	public List<DocumentFile> loadFiles(String... paths) {
 		batchWriter.initialize();
 		List<DocumentFile> documentFiles = getDocumentFiles(paths);
+		writeDocumentFiles(documentFiles);
+		return documentFiles;
+	}
+
+	protected final List<DocumentFile> getDocumentFiles(String... paths) {
+		initializeDocumentFileReader();
+		return documentFileReader.readDocumentFiles(paths);
+	}
+
+	protected final void writeDocumentFiles(List<DocumentFile> documentFiles) {
 		if (documentFiles != null && !documentFiles.isEmpty()) {
 			writeBatchOfDocuments(documentFiles, 0);
 			if (waitForCompletion) {
 				batchWriter.waitForCompletion();
 			}
 		}
-		return documentFiles;
-	}
-
-	public List<DocumentFile> getDocumentFiles(String... paths) {
-		initializeDocumentFileReader();
-		return documentFileReader.readDocumentFiles(paths);
 	}
 
 	/**

--- a/src/main/java/com/marklogic/client/ext/helper/ClientHelper.java
+++ b/src/main/java/com/marklogic/client/ext/helper/ClientHelper.java
@@ -5,11 +5,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.eval.ServerEvaluationCall;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentCollections;
 import com.marklogic.client.io.SearchHandle;
-import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.MatchDocumentSummary;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StringQueryDefinition;
@@ -68,14 +66,4 @@ public class ClientHelper extends LoggingObject {
         return getClient().newServerEval().xquery(expr).evalAs(String.class);
     }
 
-    public int getMLEffectiveVersion() {
-		int version = -1;
-		StringBuilder script = new StringBuilder("xdmp.effectiveVersion();");
-		ServerEvaluationCall call = client.newServerEval().javascript(script.toString());
-		if (call != null) {
-			String node = call.eval(new StringHandle()).get();
-			version = Integer.parseInt(node);
-		}
-		return version;
-	}
 }

--- a/src/main/java/com/marklogic/client/ext/schemasloader/impl/TdeUtil.java
+++ b/src/main/java/com/marklogic/client/ext/schemasloader/impl/TdeUtil.java
@@ -1,0 +1,22 @@
+package com.marklogic.client.ext.schemasloader.impl;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.io.StringHandle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+abstract class TdeUtil {
+
+	public static final String TDE_COLLECTION = "http://marklogic.com/xdmp/tde";
+
+	private final static Logger logger = LoggerFactory.getLogger(TdeUtil.class);
+
+	public static boolean templateBatchInsertSupported(DatabaseClient client) {
+		final int markLogic10Dot9 = 10000900;
+		String result = client.newServerEval().javascript("xdmp.effectiveVersion()").eval(new StringHandle()).get();
+		if (logger.isDebugEnabled()) {
+			logger.debug("Checking if templateBatchInsert is supported; MarkLogic version: " + result);
+		}
+		return Integer.parseInt(result) >= markLogic10Dot9;
+	}
+}

--- a/src/test/java/com/marklogic/client/ext/schemasloader/impl/LoadRulesetsTest.java
+++ b/src/test/java/com/marklogic/client/ext/schemasloader/impl/LoadRulesetsTest.java
@@ -14,7 +14,8 @@ public class LoadRulesetsTest extends AbstractSchemasTest {
 
 	@Test
 	public void test() {
-		DefaultSchemasLoader loader = new DefaultSchemasLoader(client);
+		// Pass in a TDE validation database to ensure that TDE validation doesn't happen for these files
+		DefaultSchemasLoader loader = new DefaultSchemasLoader(client, "Documents");
 		List<DocumentFile> files = loader.loadSchemas(Paths.get("src", "test", "resources", "rulesets", "collection-test").toString());
 		assertEquals(2, files.size());
 

--- a/src/test/java/com/marklogic/client/ext/schemasloader/impl/LoadSchemasTest.java
+++ b/src/test/java/com/marklogic/client/ext/schemasloader/impl/LoadSchemasTest.java
@@ -8,7 +8,8 @@ import org.junit.jupiter.api.Test;
 import java.nio.file.Paths;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LoadSchemasTest extends AbstractSchemasTest {
 
@@ -23,7 +24,7 @@ public class LoadSchemasTest extends AbstractSchemasTest {
 		assertEquals(5, files.size());
 
 		ClientHelper helper = new ClientHelper(client);
-		List<String> uris = helper.getUrisInCollection("http://marklogic.com/xdmp/tde");
+		List<String> uris = helper.getUrisInCollection(TdeUtil.TDE_COLLECTION);
 		assertEquals(4, uris.size(), "The non-tde/ruleset.txt file should not be in the TDE collection");
 		assertTrue(uris.contains("/child/child.tdej"));
 		assertTrue(uris.contains("/child/grandchild/grandchild.tdex"));
@@ -38,7 +39,7 @@ public class LoadSchemasTest extends AbstractSchemasTest {
 		assertEquals(2, files.size());
 
 		ClientHelper helper = new ClientHelper(client);
-		List<String> uris = helper.getUrisInCollection("http://marklogic.com/xdmp/tde");
+		List<String> uris = helper.getUrisInCollection(TdeUtil.TDE_COLLECTION);
 		assertEquals(2, uris.size());
 		assertTrue(uris.contains("/tde/good-schema.json"));
 		assertTrue(uris.contains("/tde/good-schema.xml"));


### PR DESCRIPTION
Resolves #149. Also fixed a problem where with ML version >= 10.0-9, all schema files were being passed into the templateBatchInsert function. Added a test to verify that this no longer occurs. 

Also added TdeUtil to store util/constant stuff for TDE functionality. 