### PR TITLE
#153: Including the templateBatchInsert script in error message

### DIFF
--- a/src/main/java/com/marklogic/client/ext/schemasloader/impl/DefaultSchemasLoader.java
+++ b/src/main/java/com/marklogic/client/ext/schemasloader/impl/DefaultSchemasLoader.java
@@ -133,7 +133,9 @@ public class DefaultSchemasLoader extends GenericFileLoader implements SchemasLo
 		try {
 			schemasDatabaseClient.newServerEval().javascript(script.toString()).eval().close();
 		} catch (Exception ex) {
-			throw new RuntimeException("Unable to load and validate TDE templates via tde.templateBatchInsert; cause: " + ex.getMessage(), ex);
+			throw new RuntimeException("Unable to load and validate TDE templates via tde.templateBatchInsert; " +
+				"cause: " + ex.getMessage() + "; the following script can be run in Query Console against your content " +
+				"database to see the TDE validation error:\n" + script, ex);
 		}
 	}
 

--- a/src/test/java/com/marklogic/client/ext/schemasloader/impl/ValidateTdeTemplatesTest.java
+++ b/src/test/java/com/marklogic/client/ext/schemasloader/impl/ValidateTdeTemplatesTest.java
@@ -30,6 +30,8 @@ public class ValidateTdeTemplatesTest extends AbstractSchemasTest {
 		final String path = Paths.get("src", "test", "resources", "bad-schemas", "bad-json").toString();
 		if (TdeUtil.templateBatchInsertSupported(client)) {
 			RuntimeException ex = assertThrows(RuntimeException.class, () -> loader.loadSchemas(path));
+			assertTrue(ex.getMessage().contains("the following script can be run in Query Console against your content " +
+				"database to see the TDE validation error"), "Unexpected message: " + ex.getMessage());
 			FailedRequestException fre = (FailedRequestException)ex.getCause();
 			assertTrue(fre.getMessage().contains("failed to apply resource at eval: Internal Server Error"),
 				"Unfortunately, the FailedRequestException does not capture why the tde.templateBatchInsert failed; " +
@@ -63,6 +65,8 @@ public class ValidateTdeTemplatesTest extends AbstractSchemasTest {
 		final String path = Paths.get("src", "test", "resources", "bad-schemas", "bad-xml").toString();
 		if (TdeUtil.templateBatchInsertSupported(client)) {
 			RuntimeException ex = assertThrows(RuntimeException.class, () -> loader.loadSchemas(path));
+			assertTrue(ex.getMessage().contains("the following script can be run in Query Console against your content " +
+				"database to see the TDE validation error"), "Unexpected message: " + ex.getMessage());
 			FailedRequestException fre = (FailedRequestException)ex.getCause();
 			assertTrue(fre.getMessage().contains("failed to apply resource at eval: Internal Server Error"),
 				"Unfortunately, the FailedRequestException does not capture why the tde.templateBatchInsert failed; " +


### PR DESCRIPTION
Intent is to help user debug the error as the Java Client does not get the actual error message, nor is it in the ML error logs. 