### PR TITLE
Bumping dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,39 +7,42 @@ plugins {
 }
 
 group = "com.marklogic"
-version = "4.3.6"
+version = "4.4-SNAPSHOT"
 
-sourceCompatibility = "8"
-targetCompatibility = "8"
+java {
+	sourceCompatibility = 1.8
+	targetCompatibility = 1.8
+}
 
 repositories {
+	mavenLocal()
 	mavenCentral()
 }
 
 dependencies {
-  api 'com.marklogic:marklogic-client-api:5.5.3'
-  api 'com.marklogic:marklogic-xcc:10.0.9'
-  api 'org.springframework:spring-context:5.3.22'
+  api 'com.marklogic:marklogic-client-api:6.0-SNAPSHOT'
+  api 'com.marklogic:marklogic-xcc:10.0.9.5'
+  api 'org.springframework:spring-context:5.3.23'
 
   implementation 'org.jdom:jdom2:2.0.6.1'
 
-	implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.6.1'
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
 
 	// This is currently an implementation dependency, though perhaps should be an api dependency due to its usage in
 	// LoggingObject; not clear yet on whether the protected Logger in that class should make this an api dependency or not
 	implementation 'org.slf4j:slf4j-api:1.7.36'
 
-  testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
-	testImplementation 'org.springframework:spring-test:5.3.22'
-	testImplementation 'org.mockito:mockito-core:4.6.1'
+  testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
+	testImplementation 'org.springframework:spring-test:5.3.23'
+	testImplementation 'org.mockito:mockito-core:4.8.1'
 
   // Used for testing loading modules from the classpath
   testImplementation files("lib/modules.jar")
 
 	// Forcing Spring to use logback instead of commons-logging
-	testImplementation "ch.qos.logback:logback-classic:1.2.11"
+	// Sticking with 1.3.x as 1.4 requires Java 11
+	testImplementation "ch.qos.logback:logback-classic:1.3.4"
 	testImplementation "org.slf4j:jcl-over-slf4j:1.7.36"
-	testImplementation "org.slf4j:slf4j-api:1.7.36"
 }
 
 test {


### PR DESCRIPTION
This requires a locally published 6.0-SNAPSHOT of java-client-api. Will hold off on merging for now. 