### PR TITLE
DEVEXP-173: Added config option for SAML token

### DIFF
--- a/src/main/java/com/marklogic/client/ext/DatabaseClientConfig.java
+++ b/src/main/java/com/marklogic/client/ext/DatabaseClientConfig.java
@@ -26,6 +26,8 @@ public class DatabaseClientConfig {
 	private String certFile;
 	private String certPassword;
 	private String externalName;
+	private String samlToken;
+
 	private X509TrustManager trustManager;
 	private DatabaseClient.ConnectionType connectionType;
 
@@ -202,5 +204,21 @@ public class DatabaseClientConfig {
 	 */
 	public void setBasePath(String basePath) {
 		this.basePath = basePath;
+	}
+
+	/**
+	 * @return
+	 * @since 4.5.0
+	 */
+	public String getSamlToken() {
+		return samlToken;
+	}
+
+	/**
+	 * @param samlToken
+	 * @since 4.5.0
+	 */
+	public void setSamlToken(String samlToken) {
+		this.samlToken = samlToken;
 	}
 }

--- a/src/main/java/com/marklogic/client/ext/DefaultConfiguredDatabaseClientFactory.java
+++ b/src/main/java/com/marklogic/client/ext/DefaultConfiguredDatabaseClientFactory.java
@@ -30,6 +30,7 @@ public class DefaultConfiguredDatabaseClientFactory implements ConfiguredDatabas
 			.withCertificateFile(config.getCertFile())
 			.withCertificatePassword(config.getCertPassword())
 			.withKerberosPrincipal(config.getExternalName())
+			.withSAMLToken(config.getSamlToken())
 			.withCloudApiKey(config.getCloudApiKey())
 			.withSSLProtocol(config.getSslProtocol())
 			.withSSLHostnameVerifier(config.getSslHostnameVerifier());

--- a/src/main/java/com/marklogic/client/ext/SecurityContextType.java
+++ b/src/main/java/com/marklogic/client/ext/SecurityContextType.java
@@ -14,6 +14,10 @@ public enum SecurityContextType {
 	CLOUD,
 	DIGEST,
 	KERBEROS,
+	/**
+	 * @since 4.5.0
+	 */
+	SAML,
 	@Deprecated // Deprecated in 4.5.0; the Java Client requires a SecurityContext
 	NONE
 }

--- a/src/test/java/com/marklogic/client/ext/NewDatabaseClientTest.java
+++ b/src/test/java/com/marklogic/client/ext/NewDatabaseClientTest.java
@@ -1,0 +1,32 @@
+package com.marklogic.client.ext;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.DatabaseClientFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class NewDatabaseClientTest {
+
+	private DatabaseClientConfig config;
+
+	@BeforeEach
+	void setup() {
+		config = new DatabaseClientConfig("localhost", 8000);
+	}
+
+	@Test
+	void saml() {
+		config.setSecurityContextType(SecurityContextType.SAML);
+		config.setSamlToken("my-token");
+
+		DatabaseClient client = new DefaultConfiguredDatabaseClientFactory().newDatabaseClient(config);
+		DatabaseClientFactory.SecurityContext context = client.getSecurityContext();
+
+		assertTrue(context instanceof DatabaseClientFactory.SAMLAuthContext);
+		DatabaseClientFactory.SAMLAuthContext samlContext = (DatabaseClientFactory.SAMLAuthContext) context;
+		assertEquals("my-token", samlContext.getToken());
+	}
+}


### PR DESCRIPTION
The main change here is that `withSAMLToken` is now invoked on the Builder option. This allows e.g. ml-app-deployer to populate the SAML token based on a user-provided input and get the expected DatabaseClient back. 